### PR TITLE
Wrap commands containing whitespace into double quotes.

### DIFF
--- a/matrix_runner/action.py
+++ b/matrix_runner/action.py
@@ -9,10 +9,10 @@ from typing import Callable, List, Iterator, Tuple, Union, AnyStr, Optional
 
 import matrix_runner.preferences as prefs
 
-from .command import Command, Result
-from .report import ReportFilter
 from ._helper import colorize
+from .command import Command, Result
 from .config import Config
+from .report import ReportFilter
 
 ActionFunction = Callable[[Config, Optional[Result]], Iterator[Union[Command, Tuple]]]
 

--- a/matrix_runner/command.py
+++ b/matrix_runner/command.py
@@ -120,6 +120,8 @@ class Command:
         cmdline = [Command._resolve_cmdlineel(el) for el in cmdline]
         cmd = shutil.which(cmdline[0])
         if cmd:
+            if ' ' in cmd:
+                cmd = f'"{cmd}"'
             cmdline[0] = cmd
         else:
             logging.error("Command '%s' not found in current environment.", cmdline[0], extra=self.extra)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -34,7 +34,7 @@ class TestAction(TestCase):
 
         # AND annotating a function as summary
         @action.summary
-        def summary(results):  # pylint: disable=unused-argument
+        def summary(_):  # pylint: disable=unused-argument
             ...
 
         # THEN the function is registered as the summary function


### PR DESCRIPTION
This is typically an issue on Windows machines using paths
like C:\Program Files.